### PR TITLE
v2.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "./node_modules/.bin/gulp dev",
-    "dev:docker": "set IS_DOCKER=true && npm run dev"
+    "dev:docker": "export IS_DOCKER=true && npm run dev"
   },
   "keywords": [
     "gulp",


### PR DESCRIPTION
- Fix: `export` the `IS_DOCKER` env variable for Docker (Linux). Follow-up for PR #32 