### PR TITLE
feat: optional extra files list watching via env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Files to watch for live reload
+EXTRA_WATCHLIST=png,jpg,svg
+
+# Uncomment this line if working in Docker on Windows OS host to enable hot reload
+# USE_POLLING=true

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Files to watch for live reload
+# Extra files to watch for live reload
 EXTRA_WATCHLIST=png,jpg,svg
 
 # Uncomment this line if working in Docker on Windows OS host to enable hot reload

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ node_modules/
 *.zip
 *.rar
 *.txt
+.env*
+
+!.env.example

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ## livereload-basic
 
-Simple localhost static website development environment for plain HTML, CSS, and JavaScript files with live reload.
+A lightweight local development environment for plain HTML, CSS,
+and JavaScript websites with live reload.
 
 Its development static hosting and file-serving architecture are closer to traditional static web servers. Uses **Gulp** and **Browser-Sync**
 
@@ -15,7 +16,7 @@ Its development static hosting and file-serving architecture are closer to tradi
 ### Content
 
 - [Dependencies](#dependencies)
-- [Installation](#nstallation)
+- [Installation](#installation)
 - [Usage](#usage)
 - [Available Scripts](#available-scripts)
 - [Usage with Docker](#usage-with-docker)
@@ -37,7 +38,7 @@ The following dependecies are used for this project. Feel free to experiment usi
 3. NodeJS 24.11.0 installed using nvm
    - node v24.11.0
    - npm v11.6.1
-4. NodeJS modules (installed using yarn)
+4. NodeJS modules (installed using npm)
 	- gulp v5.0.1
 	- browser-sync v3.0.4
 
@@ -49,6 +50,18 @@ The following dependecies are used for this project. Feel free to experiment usi
 2. Install dependencies.<br>
 `npm install`
 
+3. To watch for file changes other than the default `.html`, `.css` and `.js` files in the `"/public"` directory, create a `.env` file from the `.env.example` file. Append additional file extensions in the `EXTRA_WATCHLIST` variable as comma-separated values eg.,
+
+   ```text
+   png,jpg,svg
+   ```
+
+### Environment Variables
+
+| Variable Name | Description |
+| EXTRA_WATCHLIST | (Optional) Extra comma-separated file extensions to watch for changes in the `"/public"` directory eg., `png,jpg,svg`. It adds extensions to the default watchlist - It does not replace the default supported extensions (`html`, `css` and `js`). |
+| USE_POLLING | Enables filesystem polling for file-change detection. Useful when running the development container with a Windows host. |
+| PORT | Port used by the development server. Defaults to `3000`. |
 
 ## Usage
 
@@ -110,10 +123,13 @@ https://hub.docker.com/r/weaponsforge/livereload-basic
 
 		```
 		├─ my-website-project
+		│   ├─ .env             # optional
 		│   ├─ public
 		│   ├─── index.html
 		│   ├─── ...
 		```
+      > 💡 **INFO**: If you want to watch file changes for other files besides HTML, CSS, and JavaScript, create a `.env` file containing an `EXTRA_WATCHLIST` variable. See [Installation - # 2](#installation) for more information.
+
 		Navigate to the root project directory (for example, `"my-website-project"`) using a terminal, then run:
 
 		```bash
@@ -124,6 +140,15 @@ https://hub.docker.com/r/weaponsforge/livereload-basic
 		docker run --rm -p 3000:3000 -v %cd%\FILE_DIRECTORY:/opt/app/public -e USE_POLLING=true weaponsforge/livereload-basic
 		```
 
+      Alternate (no `.env` file with `EXTRA_WATCHLIST`)
+
+      ```bash
+		# On Windows OS (Command Prompt)
+		docker run --rm -p 3000:3000 -v %cd%\FILE_DIRECTORY:/opt/app/public -e USE_POLLING=true -e EXTRA_WATCHLIST=png,jpg weaponsforge/livereload-basic
+      ```
+
+
+
       > 💡**TIP:**<br>
       > _To use other port bindings aside from the default `3000`:_
       > 1. Add a `PORT` environment variable eg., `-e PORT=3003`
@@ -131,11 +156,10 @@ https://hub.docker.com/r/weaponsforge/livereload-basic
 
 	- Using Docker compose (2nd option):<br>
 	    - `docker compose up`
-      - > **INFO:** Uncomment the following lines in the `docker-compose.yml` file when working in a **Windows host**.
-         ```yml
-         environment:
-           # Enable USE_POLLING if working in Windows WSL2 to enable live reload
-           - USE_POLLING=true
+      - > **INFO:** Create a `.env` file containing `USE_POLLING=true` when working in a **Windows host**. See the `.env.example` file for information.
+         ```txt
+         # Uncomment this line if working in Docker on Windows OS host to enable hot reload
+         USE_POLLING=true
          ```
       - > **INFO:** Enable using **other ports** - uncomment the following lines in the `docker-compose.yml` and expose the new port under the `"ports"` section.
          ```yml
@@ -167,7 +191,7 @@ https://hub.docker.com/r/weaponsforge/livereload-basic
 
 ### Development Image
 
-The **development** Docker image contains Node runtime, Gulp, Browser-Sync and Yarn dependencies, and the latest repository source codes for local development. Build it with:
+The **development** Docker image contains Node runtime, Gulp, and Browser-Sync dependencies, and the latest repository source codes for local development. Build it with:
 
 `docker compose build`
 
@@ -177,7 +201,11 @@ The **production** Docker image contains the static website running in an Nginx 
 
 `docker compose -f docker-compose.prod.yml build`
 
-## Deployment with GitHub Actions
+<br>
+
+## Maintainer Documentation
+
+### Deployment with GitHub Actions
 
 This repository deploys the **local development** Docker image to Docker Hub on the creation of new Release/Tags.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,9 @@ services:
   weaponsforge.livereload-basic:
     container_name: weaponsforge-localhost-basic
     image: weaponsforge/livereload-basic:latest
+    env_file:
+      - path: .env
+        required: false
     build:
       context: .
       dockerfile: Dockerfile
@@ -13,9 +16,6 @@ services:
       - "3000:3000"
       - "9229:9229"
     # environment:
-      # Enable USE_POLLING if working in Windows WSL2 to enable live reload
-      # - USE_POLLING=true
-      #
       # Use other ports aside from the default 3000
       # Ensure to map and expose this port under the "ports" section eg., -"3002:3002"
       # - PORT=3002

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,6 @@
 import gulp from 'gulp'
 import browserSync from 'browser-sync'
+import { loadWatchlist } from './scripts/watchlist.js'
 
 browserSync.create()
 
@@ -15,24 +16,19 @@ const server = function () {
   })
 }
 
+// Load supported file extensions
+const fileExtensions = loadWatchlist()
+const fileWatchList = fileExtensions.map(file => `${root}/**/*.${file}`)
+console.log(`[LOG] watching files: ${fileExtensions.toString()}\n`)
+
 // Files to watch for changes then reload browser
+// Use gulp interval and polling if working in Windows WSL2 to enable hot reload
 const watch = function () {
-  const html = `${root}/**/*.html`
-  const css = `${root}/**/*.css`
-  const js = `${root}/**/*.js`
-
-  // Use gulp interval and polling if working in Windows WSL2 to enable hot reload
-  gulp.watch(html,
-    (process.env.USE_POLLING && { interval: 1000, usePolling: true })
-  ).on('change', browserSync.reload)
-
-  gulp.watch(css,
-    (process.env.USE_POLLING && { interval: 1000, usePolling: true })
-  ).on('change', browserSync.reload)
-
-  gulp.watch(js,
-    (process.env.USE_POLLING && { interval: 1000, usePolling: true })
-  ).on('change', browserSync.reload)
+  fileWatchList.forEach(file => {
+    gulp.watch(file,
+      (process.env.USE_POLLING && { interval: 1000, usePolling: true })
+    ).on('change', browserSync.reload)
+  })
 }
 
 // Gulp tasks

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "scripts": {
     "start": "node server.js",
-    "dev": "gulp dev",
-    "dev:docker": "export IS_DOCKER=true && gulp dev",
+    "dev": "node --env-file-if-exists=.env ./node_modules/gulp/bin/gulp.js dev",
+    "dev:docker": "export IS_DOCKER=true && npm run dev",
     "info": "node scripts/envinfo"
   },
   "keywords": [

--- a/scripts/watchlist.js
+++ b/scripts/watchlist.js
@@ -1,0 +1,18 @@
+
+/**
+ * Loads list of file extensions to watch for changes
+ * in the `"public"` directory for live reload.
+ * @returns {string[]} List of file extensions
+ */
+export const loadWatchlist = () => {
+  const defaultFiles = ['html', 'css', 'js']
+  const files = process.env.EXTRA_WATCHLIST ?? ''
+
+  const filesList = files
+    .split(',')
+    .map(item => item.trim())
+    .filter(item => item !== '')
+
+
+  return Array.from(new Set([...defaultFiles, ...filesList]))
+}


### PR DESCRIPTION
## Summary

- Feat: enable watching for file changes via the `EXTRA_WATCHLIST` env variable. It adds to the default watch list of `html`, `css` and `js`

## Related Issues

- Satisfies feature request [#48](https://github.com/weaponsforge/livereload-basic/issues/48). To add `.scss` support in another PR

## Type of Change
- [x] New feature
- [x] Documentation

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/weaponsforge/livereload-basic/blob/dev/CONTRIBUTING.md)
- [x] I have tested my changes locally
- [x] I have linked relevant issues
