### PR TITLE
v2.2.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name }}
+      - name: Build Sass
+        run: |
+          npm ci
+          npm run build
       - name: List files for publish
         run: cd public && ls -l -a
       - name: Deploy to Github Pages
@@ -22,7 +26,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
           publish_branch: gh-pages
-          exclude_assets: '*.scss'
+          exclude_assets: 'public/**.scss'
 
   docker-build-push-tag:
     name: Push Tagged Image

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 *.zip
 *.rar
 *.txt
+*.map
 .env*
 
 !.env.example

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Sets the `IS_DOCKER=true` environment variable before running the Gulp and Brows
 
 Runs a simple ExpressJS web server serving the static website app using its static middleware.
 
+### `npm run build`
+
+Builds `.css` files from `.scss` files within the `"/public"` directory.
+
 ### `npm run info`
 
 Logs the current development environment information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "livereload-basic",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "livereload-basic",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "devDependencies": {
         "browser-sync": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "livereload-basic",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Simple localhost static website development environment for HTML, CSS and JavaScript files with live reload using Gulp and Browser-Sync",
   "type": "module",
   "main": "server.js",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "node --env-file-if-exists=.env ./node_modules/gulp/bin/gulp.js dev",
+    "build": "sass public/",
     "dev:docker": "export IS_DOCKER=true && npm run dev",
     "info": "node scripts/envinfo"
   },


### PR DESCRIPTION
## Summary

- Chore: create a `sass` build script for only building `.css` from `.scss`
- Fix: build sass files on publish to GitHub Pages

## Related Issues
- Follow-up minor fix for [Issue #52](https://github.com/weaponsforge/livereload-basic/issues/52)

## Type of Change
- [x] Bug fix
- [x] Documentation

## Checklist
- [x] I have read the [CONTRIBUTING.md](https://github.com/weaponsforge/livereload-basic/blob/dev/CONTRIBUTING.md)
- [x] I have tested my changes locally
